### PR TITLE
Fixed running the app inside a framework

### DIFF
--- a/Classes/KKGoogleAnalytics.m
+++ b/Classes/KKGoogleAnalytics.m
@@ -223,7 +223,8 @@ static NSString *const KKGoogleAnalyticsErrorDomain = @"KKGoogleAnalyticsErrorDo
 		return _managedObjectModel;
 	}
 
-	NSURL *modelURL = [[NSBundle mainBundle] URLForResource:@"GoogleAnalytics" withExtension:@"momd"];
+        NSBundle *frameworkBundle = ([NSBundle bundleForClass:[KKGoogleAnalytics class]]) ? : [NSBundle mainBundle];
+	NSURL *modelURL = [frameworkBundle URLForResource:@"GoogleAnalytics" withExtension:@"momd"];
 	_managedObjectModel = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
 	return _managedObjectModel;
 }


### PR DESCRIPTION
When the pod is installed inside a framework (a requirement for swift), you can no longer access the main bundle. This fixes the crash that causes.