### PR TITLE
Change endpoint to SSL and to batch

### DIFF
--- a/Classes/KKGoogleAnalytics.m
+++ b/Classes/KKGoogleAnalytics.m
@@ -142,7 +142,7 @@ static NSString *const KKGoogleAnalyticsErrorDomain = @"KKGoogleAnalyticsErrorDo
 		[payload appendFormat:@"%@\n", [obj valueForKey:@"text"]];
 	}];
 
-	NSURL *URL = [NSURL URLWithString:@"http://www.google-analytics.com/collect"];
+	NSURL *URL = [NSURL URLWithString:@"https://ssl.google-analytics.com/collect"];
 	NSMutableURLRequest *HTTPRequest = [NSMutableURLRequest requestWithURL:URL cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:60.0];
 	[HTTPRequest setHTTPMethod:@"POST"];
 	[HTTPRequest setHTTPBody:[payload dataUsingEncoding:NSUTF8StringEncoding]];

--- a/Classes/KKGoogleAnalytics.m
+++ b/Classes/KKGoogleAnalytics.m
@@ -142,7 +142,7 @@ static NSString *const KKGoogleAnalyticsErrorDomain = @"KKGoogleAnalyticsErrorDo
 		[payload appendFormat:@"%@\n", [obj valueForKey:@"text"]];
 	}];
 
-	NSURL *URL = [NSURL URLWithString:@"https://ssl.google-analytics.com/collect"];
+	NSURL *URL = [NSURL URLWithString:@"https://ssl.google-analytics.com/batch"];
 	NSMutableURLRequest *HTTPRequest = [NSMutableURLRequest requestWithURL:URL cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:60.0];
 	[HTTPRequest setHTTPMethod:@"POST"];
 	[HTTPRequest setHTTPBody:[payload dataUsingEncoding:NSUTF8StringEncoding]];


### PR DESCRIPTION
It's better to convert the Google Analytics endpoint to SSL. Otherwise, xcode complains about App Transport Security.

I also noticed that the requests were being made in batch. I've change the endpoint appropriately. The old collect endpoint used to ignore event label.
https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide